### PR TITLE
Fix the rosdistro targeted for the rolling release track.

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -97,7 +97,7 @@ tracks:
     release_inc: '2'
     release_repo_url: null
     release_tag: :{version}
-    ros_distro: foxy
+    ros_distro: rolling
     vcs_type: git
     vcs_uri: https://github.com/tuw-robotics/tuw_geometry.git
     version: :{auto}


### PR DESCRIPTION
Bloom makes a distinction between release tracks and rosdistros, which both supports non-ROS uses of bloom and potentially (although this is not used in practice) different release tracks for the same repository within the same rosdistro. Most bloom configurations use exactly one track per rosdistro, named together.

In fact recent versions of bloom will infer the track name from the rosdistro name when no track name is provided.

This should resolve the issues with this package not properly generating release artifacts for Rolling because generating a Rolling release would execute a release targeting Foxy instead.